### PR TITLE
Semantics in Installation via Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ Plug "gfeiyou/command-center.nvim"
 ### Packer
 
 ```lua
-use { "nvim-telescope/telescope.nvim" }
-use { "gfeiyou/command-center.nvim" }
+use {
+  "gfeiyou/command-center.nvim",
+  requires = { "nvim-telescope/telescope.nvim" }
+}
 ```
 
 ## Setup and configuration


### PR DESCRIPTION
Makes packer uninstall Telescope too if CC is uninstalled unless required elsewhere. One could also put the loading part into `config` in the `use` section, too:

```lua
use {
  "gfeiyou/command-center.nvim",
  requires = "nvim-telescope/telescope.nvim",
  config = function()
    require("telescope").load_extension('command_center')
  end
}
```