### PR TITLE
Add prompt_title option to user_opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ telescope.setup {
       -- When set to false,
       -- The description compoenent will be empty if it is not specified
       auto_replace_desc_with_cmd = true,
+
+      -- Default title to Telescope prompt
+      prompt_title = "Command Center",
     }
   }
 }

--- a/lua/telescope/_extensions/command_center.lua
+++ b/lua/telescope/_extensions/command_center.lua
@@ -30,6 +30,7 @@ local user_opts = {
   },
   separator = " ",
   auto_replace_desc_with_cmd = true,
+  prompt_title = "Command Center",
 }
 
 -- Override default opts by user
@@ -119,7 +120,7 @@ local function run(filter)
 
   -- opts = opts or {}
   pickers.new(opts, {
-    prompt_title = "Command Center",
+    prompt_title = opts.prompt_title,
 
     finder = finders.new_table({
       results = filtered_items,


### PR DESCRIPTION
This allows users to override the prompt title, for example hiding it completely by setting it to `false`