### PR TITLE
feat: fix commands order in prompt (closes #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ for `command_center`:
     command_center.component.CATEGORY,
   },
 
-  -- Spcify by what components that search results are ordered;
+  -- Spcify by what components the commands is sorted
   -- Order does not matter
   sort_by = {
     command_center.component.DESC,

--- a/lua/command_center/init.lua
+++ b/lua/command_center/init.lua
@@ -5,22 +5,26 @@ local constants = require("command_center.constants")
 local component = constants.component
 local max_len = constants.max_len
 
+--Actual comamnd_center.items are stored here
+M._items = {}
+
 ---Process commands
 ---@param items table? commands to be processed
 ---@param opts table? additional options
 ---@param add_callback function? funciton to be excuted if item's `mode` contains `ADD`
 ---@param set_callback function? function to be executed if item's `mode` contains `SET`
 local function process_commands(items, opts, set_callback, add_callback)
-
   -- Early exit from items is not an non-empty list
-  if not utils.is_nonempty_list(items) then return end
+  if not utils.is_nonempty_list(items) then
+    return
+  end
   opts = utils.convert_opts(opts)
 
   for _, item in ipairs(items) do
-
     item = utils.convert_item(item, opts)
-    if not item then goto continue end
-
+    if not item then
+      goto continue
+    end
 
     -- Register/unregister the keybindings
     if item.mode == constants.mode.SET or item.mode == constants.mode.ADD_SET then
@@ -41,22 +45,22 @@ local function process_commands(items, opts, set_callback, add_callback)
   end
 end
 
---Actual comamnd_center.items are stored here
-M._items = {}
-
 ---Add commands into command_center if `mode` contains `ADD`;
 ---Set the keybindings in the command if `mode` constains `SET`
 ---@param items table? the list of commands to be removed; do nothing if nil or empty
 ---@param opts table? additional options
 function M.add(items, opts)
-
   local set_callback = function(id, item)
-    if M._items[id] then return end
+    if M._items[id] then
+      return
+    end
     utils.set_converted_keys(item.keys)
   end
 
   local add_callback = function(id, item)
-    if M._items[id] then return end
+    if M._items[id] then
+      return
+    end
 
     -- Update max length
     for _, comp in pairs(constants.component) do
@@ -78,15 +82,18 @@ end
 ---@param items table the list of commands to be removed; do nothing if nil or empty
 ---@param opts table? additional options; share the same format as the opts for `add()`
 function M.remove(items, opts)
-
   local set_callback = function(id, item)
-    if not M._items[id] then return end
+    if not M._items[id] then
+      return
+    end
     -- utils.delete_keybindings(item.keys, item.cmd)
     utils.del_converted_keys(item.keys)
   end
 
   local add_callback = function(id, _)
-    if not M._items[id] then return end
+    if not M._items[id] then
+      return
+    end
     M._items[id] = nil
   end
 
@@ -111,7 +118,7 @@ M.mode = {
 
   ADD = constants.mode.ADD,
   SET = constants.mode.SET,
-  ADD_SET = constants.mode.ADD_SET
+  ADD_SET = constants.mode.ADD_SET,
 }
 
 M.component = {
@@ -132,6 +139,5 @@ M.component = {
   KEYS = constants.component.KEYS_STR,
   CAT = constants.component.CAT,
 }
-
 
 return M

--- a/lua/telescope/_extensions/command_center.lua
+++ b/lua/telescope/_extensions/command_center.lua
@@ -89,10 +89,10 @@ local function setup(opts)
   user_opts = vim.tbl_extend("force", user_opts, opts or {})
 end
 
-
 local function run(filter)
   filter = filter or {}
   local filtered_items, cnt = utils.filter_items(M._items, filter)
+  filtered_items = utils.sort_items(filtered_items, user_opts.sort_by)
 
   local opts = vim.deepcopy(user_opts)
 
@@ -103,7 +103,6 @@ local function run(filter)
     local component_info = {}
 
     for _, v in ipairs(opts.components) do
-
       -- When user chooses to replace desc with cmd ...
       if v == component.DESC and opts.auto_replace_desc_with_cmd then
         table.insert(display, entry.value[component.REPLACED_DESC])
@@ -135,7 +134,6 @@ local function run(filter)
     finder = finders.new_table({
       results = filtered_items,
       entry_maker = function(entry)
-
         -- Concatenate components specified in `sort_by` for better sorting
         local ordinal = ""
         for _, v in ipairs(opts.sort_by) do
@@ -145,7 +143,7 @@ local function run(filter)
         return {
           value = entry,
           display = make_display,
-          ordinal = ordinal
+          ordinal = ordinal,
         }
       end,
     }),
@@ -157,7 +155,9 @@ local function run(filter)
         actions.close(prompt_bufnr)
         local selection = action_state.get_selected_entry()
 
-        if not selection then return false end
+        if not selection then
+          return false
+        end
 
         -- Handle keys as if they were typed
         local cmd = selection.value[component.CMD]
@@ -170,20 +170,18 @@ local function run(filter)
       end)
       return true
     end,
-
   })
 
   -- MARK: Save all current settings
   -- vim.deepcopy() can't copy getfenv(),
   -- Use force extend instead, as inpsired by hydra.nvim
-  local env = vim.tbl_deep_extend('force', getfenv(), {
-    vim = { o = {}, go = {}, bo = {}, wo = {} }
+  local env = vim.tbl_deep_extend("force", getfenv(), {
+    vim = { o = {}, go = {}, bo = {}, wo = {} },
   }) --[[@as table]]
-  local o   = env.vim.o
-  local go  = env.vim.go
-  local bo  = env.vim.bo
-  local wo  = env.vim.wo
-
+  local o = env.vim.o
+  local go = env.vim.go
+  local bo = env.vim.bo
+  local wo = env.vim.wo
 
   -- MARK: Start telescope
   vim.schedule(function()


### PR DESCRIPTION
Commands are now sorted upon the prompt is shown (before any text is entered to the prompt) according to the `sort_by` field set in the `setup` function