### PR TITLE
feat(lazy): get keymaps when type(keys) == function

### DIFF
--- a/lua/commander/converter.lua
+++ b/lua/commander/converter.lua
@@ -10,7 +10,7 @@ function M.get_lazy_keys(set_plugin_name_as_cat)
   if lazy_commands then return lazy_commands end
 
   for _, plugin_config in ipairs(lazy.plugins()) do
-    local keys = plugin_config.keys
+    local keys = require("lazy.core.plugin").values(plugin_config, "keys")
     local main = require("lazy.core.loader").get_main(plugin_config)
     if keys then
       for _, key in ipairs(keys) do


### PR DESCRIPTION
This PR makes gets the returned value of `plugin_config.keys` when the user defines a plugin's spec `keys` value as a function that returns a table, instead of a table directly.

The [plugin spec](https://github.com/folke/lazy.nvim#-plugin-spec) for lazy.nvim lets you define `keys` in a plugin spec as a function: `fun(self:LazyPlugin, keys:string[]):(string | LazyKeysSpec)[]`

Here's a simple case from my config:

```lua
return {
  {
    "saccarosium/neomarks",
    keys = function()
      local neomarks = require("neomarks")
      return {
        { "m<C-m>", function() neomarks.mark_file() end, desc = "Neomark: mark file" },
        { "m<C-t>", function() neomarks.menu_toggle() end, desc = "Neomark: toggle menu" },
        -- etc.
      }
    end,
    opts = {
      -- etc.
    }
  },
}
```

With this setup, in the current version of commander, I get the following error:

```
Failed to run `config` for commander.nvim

...are/nvim/lazy/commander.nvim/lua/commander/converter.lua:16: bad argument #1 to 'ipairs' (table expected, got function)

# stacktrace:
  - /commander.nvim/lua/commander/converter.lua:16 _in_ **get_lazy_keys**
  - /commander.nvim/lua/commander/init.lua:18 _in_ **setup**
```

This is because the value of `plugin_config.keys` is the function I defined above, not the return value. The change in this PR calls a lazy.nvim core function to get the return value of `plungin_config.keys` if it is a function.

Another approach would be something like  `if type(keys) == "function" then keys = keys() end`. But using the core function might keep up with any upstream changes and features of lazy on its own (or just as easily break, and I'm banking on the core function being steady)

Hope I'm taking all the right things into account. Thanks for integrating lazy into commander (with a nod to @technicalpickles )!