### PR TITLE
Resolved issue that was causing the description to not be added to the keymap

### DIFF
--- a/lua/commander/model/Command.lua
+++ b/lua/commander/model/Command.lua
@@ -136,7 +136,7 @@ function Command:parse(item, opts)
 
   -- 3.2 If there is only one keymap in keys
   if #item.keys >= 2 and type(item.keys[2]) ~= "table" then
-    local keymap, err = Keymap:parse(item.keys)
+    local keymap, err = Keymap:parse(item.keys, item.desc)
     if err then
       return nil, "keys" .. err
     end
@@ -148,7 +148,7 @@ function Command:parse(item, opts)
 
   -- 3.3 If keys is a list
   for i, key in ipairs(item.keys) do
-    local keymap, err = Keymap:parse(key)
+    local keymap, err = Keymap:parse(key, item.desc)
     if err then
       return nil, "keys[" .. i .. "]" .. err
     end

--- a/lua/commander/model/Keymap.lua
+++ b/lua/commander/model/Keymap.lua
@@ -15,9 +15,10 @@ Keymap.__mt = { __index = Keymap }
 
 ---Parse an item into Keymap object
 ---@param itemKey CommanderItemKey
+---@param desc string?
 ---@return CommanderKeymap | nil
 ---@return string | nil
-function Keymap:parse(itemKey)
+function Keymap:parse(itemKey, desc)
   itemKey = itemKey or {}
   local keymap = setmetatable({}, Keymap.__mt)
 
@@ -25,6 +26,11 @@ function Keymap:parse(itemKey)
   keymap.modes = type(itemKey[1]) == "table" and itemKey[1] or { itemKey[1] }
   keymap.lhs = itemKey[2]
   keymap.opts = itemKey[3] or {}
+
+  -- 1.1, Check if there is a description
+  if desc ~= nil then
+    keymap.opts["desc"] = desc
+  end
 
   -- 2, validate lhs and opts
   local _, err = pcall(vim.validate, {

--- a/lua/tests/keymap_spec.lua
+++ b/lua/tests/keymap_spec.lua
@@ -39,6 +39,20 @@ describe("Keymap:parse()", function()
 		assert.True(keymap.opts.buffer)
 	end)
 
+	it("keymap with desc", function()
+		local item, keymap, err, desc
+
+		item = { { "n" }, "<leader>l", { noremap = false, buffer = true } }
+		desc = "[L]ogs"
+		keymap, err = Keymap:parse(item, desc)
+		assert.Nil(err)
+		assert.equal("n", keymap.modes[1])
+		assert.equal("<leader>l", keymap.lhs)
+		assert.equal("[L]ogs", keymap.opts.desc)
+		assert.False(keymap.opts.noremap)
+		assert.True(keymap.opts.buffer)
+	end)
+
 	it("keymap without mode", function()
 		local item = { nil, "<leader>a", nil }
 		local keymap, err = Keymap:parse(item)


### PR DESCRIPTION
Resolved problems mentioned in issue #13 .
It seemed that the description was not added to the key maps. Which was causing it to not pass the descriptions properly. Resolved it with this implementation.

Pre 0.2 version:
![2024-03-14_00-50](https://github.com/FeiyouG/commander.nvim/assets/22025068/96a75c07-e11d-4510-9965-bed3abe68b9b)

Current version:
![2024-03-14_00-39](https://github.com/FeiyouG/commander.nvim/assets/22025068/c55f0981-c4f8-4fa2-8c87-1959778b3582)

As you can see the description was never added before the keymap.set was done which was the case before the 0.2 refactor.