### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ return {
 ### A minimal working example
 ```lua
 -- Add a new command
-require("commander.nvim").add({
+require("commander").add({
   {
     desc = "Open commander",
     cmd = require("commander").show,


### PR DESCRIPTION
change `require("commander.nvim")` to `require("commander")`

Noticed this while setting up the plugin. 